### PR TITLE
Fix documentation

### DIFF
--- a/Documentation/index.html
+++ b/Documentation/index.html
@@ -267,7 +267,7 @@ android.permission.WRITE_EXTERNAL_STORAGE</pre>
 							<p>Than you have to add the following dependencies into your app gradle file:</p>
 							<pre class="prettyprint">dependencies {
     ....
-    implementation 'com.google.android.gms:play-services-ads:16.+'
+    implementation 'com.google.android.gms:play-services-ads:19.+'
 }</pre>
 							<p>Banner is showed inside the following QML item:</p>
 							<pre class="prettyprint">import QtAndroidTools 1.0
@@ -320,7 +320,7 @@ android.permission.WRITE_EXTERNAL_STORAGE</pre>
 							<p>Than you have to add the following dependencies into your app gradle file:</p>
 							<pre class="prettyprint">dependencies {
     ....
-    implementation 'com.google.android.gms:play-services-ads:16.+'
+    implementation 'com.google.android.gms:play-services-ads:19.+'
 }</pre>
 						<p>Interstitial ad show on full screen but you have to define the AdMob <i>unitId</i> using the item as follow:</p>
 							<pre class="prettyprint">QtAndroidAdMobInterstitial {
@@ -365,7 +365,7 @@ android.permission.WRITE_EXTERNAL_STORAGE</pre>
 							<p>Than you have to add the following dependencies into your app gradle file:</p>
 							<pre class="prettyprint">dependencies {
     ....
-    implementation 'com.google.android.gms:play-services-ads:16.+'
+    implementation 'com.google.android.gms:play-services-ads:19.+'
 }</pre>
 						<p>Rewarded Video ad show on full screen but you have to define the AdMob <i>unitId</i> using the item as follow:</p>
 							<pre class="prettyprint">QtAndroidAdMobRewardedVideo {


### PR DESCRIPTION
# Update documentation please.
If will add the **com.google.android.gms:play-services-ads:16.+** as a dependency into **build.gradle** then you have a undefined symbols errors.
```bash
Full recompilation is required because no incremental change information is available. This is usually caused by clean builds or changing compiler arguments.
file or directory '/root/worker/cmakeAndroid_v8/AndroidBuilder_v8/QuasarApp/Hanoi-Towers/cmake_build/HanoiTowers/client/HanoiTowers-arm64-v8a/java', not found
file or directory '/root/worker/cmakeAndroid_v8/AndroidBuilder_v8/QuasarApp/Hanoi-Towers/cmake_build/HanoiTowers/client/HanoiTowers-arm64-v8a/src/release/java', not found
Compiling with JDK Java compiler API.
/root/worker/cmakeAndroid_v8/AndroidBuilder_v8/QuasarApp/Hanoi-Towers/cmake_build/HanoiTowers/client/HanoiTowers-arm64-v8a/src/com/falsinsoft/qtandroidtools/AndroidAdMob.java:31: error: package com.google.android.gms.ads.initialization does not exist
import com.google.android.gms.ads.initialization.InitializationStatus;
                                                ^
/root/worker/cmakeAndroid_v8/AndroidBuilder_v8/QuasarApp/Hanoi-Towers/cmake_build/HanoiTowers/client/HanoiTowers-arm64-v8a/src/com/falsinsoft/qtandroidtools/AndroidAdMob.java:32: error: package com.google.android.gms.ads.initialization does not exist
import com.google.android.gms.ads.initialization.OnInitializationCompleteListener;
                                                ^
/root/worker/cmakeAndroid_v8/AndroidBuilder_v8/QuasarApp/Hanoi-Towers/cmake_build/HanoiTowers/client/HanoiTowers-arm64-v8a/src/com/falsinsoft/qtandroidtools/AndroidAdMob.java:69: error: cannot find symbol
    private class MobileAdsInitializationListener implements OnInitializationCompleteListener
                                                             ^
  symbol:   class OnInitializationCompleteListener
  location: class AndroidAdMob
/root/worker/cmakeAndroid_v8/AndroidBuilder_v8/QuasarApp/Hanoi-Towers/cmake_build/HanoiTowers/client/HanoiTowers-arm64-v8a/src/com/falsinsoft/qtandroidtools/AndroidAdMob.java:72: error: cannot find symbol
        public void onInitializationComplete(InitializationStatus initializationStatus)
                                             ^
  symbol:   class InitializationStatus
  location: class AndroidAdMob.MobileAdsInitializationListener
/root/worker/cmakeAndroid_v8/AndroidBuilder_v8/QuasarApp/Hanoi-Towers/cmake_build/HanoiTowers/client/HanoiTowers-arm64-v8a/src/com/falsinsoft/qtandroidtools/AndroidAdMob.java:45: error: incompatible types: AndroidAdMob.MobileAdsInitializationListener cannot be converted to String
            MobileAds.initialize(activityInstance, new MobileAdsInitializationListener());
                                                   ^
/root/worker/cmakeAndroid_v8/AndroidBuilder_v8/QuasarApp/Hanoi-Towers/cmake_build/HanoiTowers/client/HanoiTowers-arm64-v8a/src/com/falsinsoft/qtandroidtools/AndroidAdMob.java:71: error: method does not override or implement a method from a supertype
        @Override
        ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some messages have been simplified; recompile with -Xdiags:verbose to get full output
6 errors
Task :compileReleaseJavaWithJavac in HanoiTowers-arm64-v8a Finished
> Task :compileReleaseJavaWithJavac FAILED
:compileReleaseJavaWithJavac (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 2.903 secs.
AAPT2 aapt2-3.6.0-6040484-linux Daemon #0: shutdown
AAPT2 aapt2-3.6.0-6040484-linux Daemon #1: shutdown
AAPT2 aapt2-3.6.0-6040484-linux Daemon #2: shutdown
AAPT2 aapt2-3.6.0-6040484-linux Daemon #3: shutdown
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':compileReleaseJavaWithJavac'.
> Compilation failed; see the compiler error output for details.
* Try:
Run with --stacktrace option to get the stack trace. Run with --debug option to get more log output. Run with --scan to get full insights.
* Get more help at https://help.gradle.org
BUILD FAILED in 35s
14 actionable tasks: 14 executed
Building the android package failed!
ninja: build stopped: subcommand failed.
program finished with exit code 1
elapsedTime=146.031578
```

* replaced the **com.google.android.gms:play-services-ads:16.+** to **com.google.android.gms:play-services-ads:19.+**
